### PR TITLE
Fixed GetNextMoveWithinTime. Added InterruptibleTask.

### DIFF
--- a/src/Game/InterruptibleTask.java
+++ b/src/Game/InterruptibleTask.java
@@ -1,0 +1,28 @@
+package Game;
+
+import Board.ReversiBoard;
+import Board.Move;
+import GameBot.GameBot;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Created by Joel Magnusson on 2016-04-06.
+ */
+public class InterruptibleTask implements Callable<Move> {
+    private GameBot bot;
+    private ReversiBoard board;
+    private int color;
+
+    public InterruptibleTask(GameBot bot, ReversiBoard board, int color){
+        this.bot = bot;
+        this.board = board;
+        this.color = color;
+    }
+
+    @Override
+    public Move call() throws Exception {
+        this.bot.calculateNextMove(this.board, this.color);
+        return this.bot.getMove();
+    }
+}


### PR DESCRIPTION
Fixed GetNextMoveWithinTime. The relevant bot thread is now killed on timeout and the bot then automatically forfeits the game.
The class InterruptibleTask has been created and added, in order for GetNextMoveWithinTime can work.
